### PR TITLE
Match buttons after aliases in /matches

### DIFF
--- a/app/controllers/concerns/alias_handling.rb
+++ b/app/controllers/concerns/alias_handling.rb
@@ -56,7 +56,7 @@ module AliasHandling
         session[:items] = @player.matches(session[:options])
         edit_message :text, text: build_matches_header(session[:items], session[:options])
         edit_message :reply_markup, reply_markup:
-          {inline_keyboard: build_paginated_buttons(session[:items], session[:button], 1)}
+          {inline_keyboard: build_paginated_url_buttons(session[:items], session[:button], 1)}
       end
     end
     answer_callback_query ""

--- a/spec/requests/telegram_heroes_spec.rb
+++ b/spec/requests/telegram_heroes_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe "/heroes", telegram_bot: :rails do
   before(:example) do
     allow_any_instance_of(User).to receive(:heroes) do
-      array = Hero.where(
-        localized_name: ["Anti-Mage",    "Zeus",          "Faceless Void",
-                         "Weaver",       "Invoker",       "Io",
-                         "Ember Spirit", "Winter Wyvern", "Mars"]
-      )
+      array = []
+      
+      array << Hero.find_by(localized_name: "Ember Spirit")
+      array << Hero.find_by(localized_name: "Faceless Void")
+      array << Hero.find_by(localized_name: "Zeus")
+      array << Hero.find_by(localized_name: "Weaver")
+      array << Hero.find_by(localized_name: "Invoker")
+      array << Hero.find_by(localized_name: "Io")
+      array << Hero.find_by(localized_name: "Anti-Mage")
+      array << Hero.find_by(localized_name: "Winter Wyvern")
+      array << Hero.find_by(localized_name: "Mars")
 
       array.each do |h|
         h.last_played = 1.day.ago.to_i
@@ -19,13 +25,13 @@ RSpec.describe "/heroes", telegram_bot: :rails do
 
       # Highest alphabetically: Anti-Mage
       # Highest games: Ember Spirit
-      array[6].games = 100
-      array[6].win   = 50
-      # Highest winrate: Zeus
-      array[1].win = 45
+      array[0].games = 100
+      array[0].win   = 50
       # Highest games with: Faceless Void
-      array[2].with_games = 80
-      array[2].with_win   = 60
+      array[1].with_games = 80
+      array[1].with_win   = 60
+      # Highest winrate: Zeus
+      array[2].win = 45
       # Highest winrate with: Weaver
       array[3].with_win = 35
       # Highest games against: Invoker
@@ -34,7 +40,7 @@ RSpec.describe "/heroes", telegram_bot: :rails do
       # Highest winrate against: Io
       array[5].against_win = 50
 
-      array.sort_by {|i| i.games * -1 }
+      array
     end
   end
 


### PR DESCRIPTION
The buttons in /matches after aliases were resolved were accidentally not linking to OpenDota. Now they are. Fixes #72.