### PR TITLE
Chat login flow, better registration errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,8 @@ gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-steam'
 gem 'omniauth-telegram', github: 'dotagem/omniauth-telegram', branch: 'master'
 
-gem 'steam-condenser', '~> 1.3.11'
+# https://github.com/Dragaera/steam-id#readme
+gem 'steam-condenser', github: 'koraktor/steam-condenser-ruby', ref: '3ee580b'
 gem 'steam-id2', '~> 0.4.5'
 
 gem 'hashie', '~> 5.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'omniauth-telegram', github: 'dotagem/omniauth-telegram', branch: 'master'
 
 # https://github.com/Dragaera/steam-id#readme
 gem 'steam-condenser', github: 'koraktor/steam-condenser-ruby', ref: '3ee580b'
-gem 'steam-id2', '~> 0.4.5'
+gem 'steam-id2', github: 'Dragaera/steam-id', branch: 'master'
 
 gem 'hashie', '~> 5.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,16 @@ GIT
     omniauth-telegram (0.2.1)
       omniauth (>= 1.0)
 
+GIT
+  remote: https://github.com/koraktor/steam-condenser-ruby.git
+  revision: 3ee580b5c5d390ee3a706357f18f2e9a2949e5c2
+  ref: 3ee580b
+  specs:
+    steam-condenser (1.3.11)
+      multi_json (~> 1.6)
+      multi_xml (~> 0.5)
+      rexml (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -273,9 +283,6 @@ GEM
     sshkit (1.21.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    steam-condenser (1.3.11)
-      multi_json (~> 1.6)
-      multi_xml (~> 0.5)
     steam-id2 (0.4.5)
       steam-condenser (~> 1.3)
     stimulus-rails (1.1.0)
@@ -343,7 +350,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.0.rc1)
   selenium-webdriver
   sprockets-rails
-  steam-condenser (~> 1.3.11)
+  steam-condenser!
   steam-id2 (~> 0.4.5)
   stimulus-rails
   tailwindcss-rails (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/Dragaera/steam-id.git
+  revision: dc106b72f5c8375b022b511368a4470b769e3fd3
+  branch: master
+  specs:
+    steam-id2 (0.4.5)
+      steam-condenser (~> 1.3)
+
+GIT
   remote: https://github.com/dotagem/omniauth-telegram.git
   revision: 45a6b3a3e322bfe5e2e706f95a8d26525efcd870
   branch: master
@@ -283,8 +291,6 @@ GEM
     sshkit (1.21.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    steam-id2 (0.4.5)
-      steam-condenser (~> 1.3)
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
     strscan (3.0.4)
@@ -351,7 +357,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   steam-condenser!
-  steam-id2 (~> 0.4.5)
+  steam-id2!
   stimulus-rails
   tailwindcss-rails (~> 2.0)
   telegram-bot (~> 0.15.6)

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -23,14 +23,15 @@ module ErrorHandling
         chat_id: update["message"]["chat"]["id"]
       )
     elsif update["callback_query"]
-      bot.answer_callback_query(
+      bot.send_message(
+        chat_id: update["callback_query"]["message"]["chat"]["id"],
         text: "Something went wrong, sorry!\n" +
         "When reporting this error, please provide the following information:\n\n" +
         "Update ID: #{update["update_id"]}\n" +
-        "Error: #{exception.inspect}",
-        show_alert: true,
-        callback_query_id: update["callback_query"]["id"]
+        "Error:\n<pre>#{CGI::escapeHTML(exception.inspect)}</pre>",
+        parse_mode: "html"
       )
+      answer_callback_query "Something went wrong, sorry!"
     elsif update["inline_query"]
       bot.answer_inline_query(
         inline_query_id: update["inline_query"]["id"],

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -2,6 +2,7 @@ module ErrorHandling
   
   private
   def error_out(exception)
+    # Collect backtrace and error information
     backtrace_size = exception.backtrace.size
     if backtrace_size >= 2 then max_range = 2
     elsif backtrace_size >= 1 then max_range = 1
@@ -11,12 +12,14 @@ module ErrorHandling
       logger.error s
     end
 
+    # Send a message with helpful information about what to do next
     if update["message"]
       bot.send_message(
         text: "Something went wrong, sorry!\n" +
         "When reporting this error, please provide the following information:\n\n" +
         "Update ID: #{update["update_id"]}\n" +
-        "Error: #{exception.inspect}",
+        "Error:\n<pre>#{CGI::escapeHTML(exception.inspect)}</pre>",
+        parse_mode: "html",
         chat_id: update["message"]["chat"]["id"]
       )
     elsif update["callback_query"]
@@ -37,10 +40,13 @@ module ErrorHandling
             id: 0,
             title: "Something went wrong, sorry!",
             description: "Send this message for error details.",
-            message_text: "Something went wrong, sorry!\n" +
-              "When reporting this error, please provide the following information:\n\n" + 
+            input_message_content: {
+              message_text: "Something went wrong, sorry!\n" +
+              "When reporting this error, please provide the following information:\n\n" +
               "Update ID: #{update["update_id"]}\n" +
-              "Error: #{exception.inspect}"
+              "Error:\n<pre>#{CGI::escapeHTML(exception.inspect)}</pre>",
+              parse_mode: "html"
+            }
           }
         ],
         cache_time: 10

--- a/app/controllers/telegram_help_controller.rb
+++ b/app/controllers/telegram_help_controller.rb
@@ -2,9 +2,11 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
   include Telegram::Bot::UpdatesController::MessageContext
   include Telegram::Bot::UpdatesController::CallbackQueryContext
   include LoginUrl
-
+  
   include ErrorHandling
   rescue_from StandardError, with: :error_out
+  
+  require 'steam_id'
   
   def help!(*)
     respond_with :message,
@@ -36,19 +38,121 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
   end
 
   def start!(*)
-    respond_with :message,
-    text: "Hello! I can fetch your Dota 2 match data and statistics " +
-    "and display them in chats. I am most useful when added to group chats.\n" +
-    "\nTo let me show your stats, I will need to know which Steam account " +
-    "belongs to which Telegram account. If you want to use my commands, you " +
-    "need to log in with the button below and complete your registration.",
-    reply_markup: {
-      inline_keyboard: [
-        [{
-          text: "Log In",
-          login_url: {url: login_callback_url}
-        }]
-      ]
-    }
+    login_button = [
+      {
+        text: "Log In (website)",
+        login_url: {url: login_callback_url}
+      }
+    ]
+
+    message_button = [
+      {
+        text: "Log In (message)",
+        url: "https://t.me/#{bot.username}?start=login"
+      }
+    ]
+
+    base_message = "Hello! I can fetch your Dota 2 match data and statistics " +
+    "and display them in chats. I am most useful when added to group chats.\n"
+
+    if update["message"]["chat"]["type"] == "private"
+      save_context :login_from_message
+      if User.find_by(telegram_id: from["id"]).steam_registered?
+        respond_with :message,
+        text: base_message + "\nYou are already signed in and ready to use the " +
+        "bot's commands! If you want to edit or remove your registration, " +
+        "you can do so on the site with the button below.",
+        reply_markup: {
+          inline_keyboard: [login_button]
+        }
+      else
+        respond_with :message,
+        text: base_message +
+        "\nTo let me show your stats, you have two options for signing in: \n\n" +
+        "a) Use the button below this message and log in with Steam through the site, or\n" +
+        "b) Send a message with a link to your Steam profile!",
+        reply_markup: {
+          inline_keyboard: [login_button]
+        }
+      end
+    else
+      respond_with :message,
+      text: base_message +
+      "\nTo let me show your stats, I will need to know which Steam account " +
+      "belongs to which Telegram account. If you want to use my commands, you " +
+      "need to log in with the button below and complete your registration.",
+      reply_markup: {
+        inline_keyboard: [login_button, message_button]
+      }
+    end
+  end
+
+  def login_from_message(*words)
+    try = words[0]
+    begin
+      r = SteamID.from_string(try, api_key: Rails.application.credentials.steam.token)
+      save_context :login_from_message
+      respond_with :message, text: "I've found #{r.profile_url} \n" +
+      "If you want to register this account, press the button below. If not, try " +
+      "sending me a different steam ID.",
+      reply_markup: {
+        inline_keyboard: [[
+          {
+            text: "Register this account",
+            callback_data: "register:#{r.account_id}"
+          }
+        ]]
+      }
+    rescue ArgumentError
+      save_context :login_from_message
+      respond_with :message, text: "I can't find that account, sorry! Please try again.\n" +
+      "You can send me a link to your profile, a steam ID number or a vanity URL."
+    end
+  end
+
+  def register_callback_query(account_id)
+    u = User.find_by(telegram_id: from["id"])
+    steam = SteamID.from_string(account_id)
+    community = SteamCondenser::Community::SteamId.new(steam.id_64)
+    removed = nil
+
+    if User.where(steam_id64: steam.id_64).any?
+      User.where(steam_id64: steam.id_64).each do |user|
+        unless user == u
+          user.steam_id64     = nil
+          user.steam_id       = nil
+          user.steam_nickname = nil
+          user.steam_avatar   = nil
+          user.steam_url      = nil
+
+          removed = true
+          user.save!
+        end
+      end
+    end
+
+    u.steam_id64     = steam.id_64
+    u.steam_id       = steam.account_id
+    u.steam_nickname = community.nickname
+    u.steam_avatar   = community.full_avatar_url
+    u.steam_url      = steam.profile_url
+
+    u.save!
+
+    message = "Your registration is now complete and you can use " +
+    "the bot's commands! If you want to edit or remove your registration, use " +
+    "<code>/account</code> and go to the website."
+
+    if removed
+      message << "\n\nAnother account in the database had this Steam account " +
+      "registered, their registration has been removed."
+    end
+
+    bot.send_message(
+      chat_id: update["callback_query"]["message"]["chat"]["id"],
+      text: message,
+      parse_mode: "html"
+    )
+    answer_callback_query ""
   end
 end

--- a/app/controllers/telegram_help_controller.rb
+++ b/app/controllers/telegram_help_controller.rb
@@ -38,7 +38,7 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
   end
 
   def start!(*)
-    login_button = [
+    website_button = [
       {
         text: "Log In (website)",
         login_url: {url: login_callback_url}
@@ -61,9 +61,10 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
         respond_with :message,
         text: base_message + "\nYou are already signed in and ready to use the " +
         "bot's commands! If you want to edit or remove your registration, " +
-        "you can do so on the site with the button below.",
+        "you can do so on the site with the button below. You can also send me" +
+        " a link to a Steam profile if you want to change your Steam account.",
         reply_markup: {
-          inline_keyboard: [login_button]
+          inline_keyboard: [website_button]
         }
       else
         respond_with :message,
@@ -72,7 +73,7 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
         "a) Use the button below this message and log in with Steam through the site, or\n" +
         "b) Send a message with a link to your Steam profile!",
         reply_markup: {
-          inline_keyboard: [login_button]
+          inline_keyboard: [website_button]
         }
       end
     else
@@ -80,9 +81,10 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
       text: base_message +
       "\nTo let me show your stats, I will need to know which Steam account " +
       "belongs to which Telegram account. If you want to use my commands, you " +
-      "need to log in with the button below and complete your registration.",
+      "need to log in with the button below and complete your registration on " +
+      "the site, or use the other button and complete it in chat.",
       reply_markup: {
-        inline_keyboard: [login_button, message_button]
+        inline_keyboard: [website_button, message_button]
       }
     end
   end

--- a/app/controllers/telegram_players_controller.rb
+++ b/app/controllers/telegram_players_controller.rb
@@ -295,7 +295,7 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
     
     if @player.nil? || !(@player.steam_registered?)
       respond_with :message, text: "You need to register before you can use that command!" +
-        "If you tried to tag another user, they may not be registered yet.\n\n" +
+        " If you tried to tag another user, they may not be registered yet.\n\n" +
         "Use the button below to open a chat with me and sign in with Steam.",
         reply_markup: {
           inline_keyboard: [[

--- a/app/controllers/telegram_users_controller.rb
+++ b/app/controllers/telegram_users_controller.rb
@@ -8,27 +8,56 @@ class TelegramUsersController < Telegram::Bot::UpdatesController
   # if you're looking for player data commands, check TelegramPlayersController
 
   def login!(*)
+    web_button = [
+      {
+        text: "Log In (website)",
+        login_url: {url: login_callback_url}
+      }
+    ]
+
+    message_button = [
+      {
+        text: "Log In (message)",
+        url: "https://t.me/#{bot.username}?start=login"
+      }
+    ]
+
     current_user = User.find_by(telegram_id: from["id"])
     if current_user && current_user.steam_registered?
       message = "Your registration is complete and you can now use the bot! " +
                 "If you want to unlink your account, use the button below to " +
                 "log in or go to #{Rails.application.credentials.base_url} " +
                 "and log in there."
+      respond_with :message,
+        text: message,
+        reply_markup: {
+          inline_keyboard: [web_button]
+        }
     else
-      message = "To use this bot, you need to log in with both Steam and " +
-                "Telegram. To complete your registration, use the button " +
-                "below to log in instantly, or go to " +
-                "#{Rails.application.credentials.base_url} and log in there."
+      if update["message"]["chat"]["type"] == "private"
+        save_context :login_from_message
+        message = "To use this bot, you need to log in with both Steam and " +
+                  "Telegram. To complete your registration, you have two options:" +
+                  "\n\na) Use the button below to log in with Steam via the website, or\n" +
+                  "b) Send me a message with a link to your Steam profile and " +
+                  "complete your registration that way."
+        respond_with :message,
+          text: message,
+          reply_markup: {
+          inline_keyboard: [web_button]
+        }
+      else
+        message = "To use this bot, you need to log in with both Steam and " +
+        "Telegram. To complete your registration, open a PM with " +
+        "me using the button below or go to the website and log in " +
+        "with Steam there."
+        respond_with :message,
+          text: message,
+          reply_markup: {
+            inline_keyboard: [web_button, message_button]
+          }
+      end
     end
-    respond_with :message,  text: message,
-                            reply_markup: {
-                              inline_keyboard: [
-                                [{
-                                  text: "Log In",
-                                  login_url: {url: login_callback_url}
-                                }]
-                              ]
-                            }
   end
 
   alias_method :log_in!,  :login!
@@ -41,13 +70,13 @@ class TelegramUsersController < Telegram::Bot::UpdatesController
               "below or go to #{Rails.application.credentials.base_url} " +
               "and log in."
     respond_with  :message, text: message,
-                            reply_markup: {
-                              inline_keyboard: [
-                                [{
-                                  text: "Log In",
-                                  login_url: {url: login_callback_url}
-                                }]
-                              ]
-                            }
+      reply_markup: {
+        inline_keyboard: [
+          [{
+            text: "Log In",
+            login_url: {url: login_callback_url}
+          }]
+        ]
+      }
   end
 end

--- a/app/controllers/telegram_webhooks_router.rb
+++ b/app/controllers/telegram_webhooks_router.rb
@@ -26,7 +26,7 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
     end
 
     # Ensure automatic user saving is skipped in tests with minimal user data
-    if defined?(from) && defined?(from["id"]) && !(from["username"].nil?)
+    if defined?(from) && defined?(from["id"]) && !(from["username"].nil?) && from["username"] != bot.username
       user = User.find_or_create_by(telegram_id: from["id"])
       user.telegram_username = from["username"].downcase
       if from["last_name"]

--- a/app/controllers/telegram_webhooks_router.rb
+++ b/app/controllers/telegram_webhooks_router.rb
@@ -25,7 +25,8 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
       from = update["callback_query"]["from"]
     end
 
-    if defined?(from) && from
+    # Ensure automatic user saving is skipped in tests with minimal user data
+    if defined?(from) && defined?(from["id"]) && !(from["username"].nil?)
       user = User.find_or_create_by(telegram_id: from["id"])
       user.telegram_username = from["username"].downcase
       if from["last_name"]

--- a/app/controllers/telegram_webhooks_router.rb
+++ b/app/controllers/telegram_webhooks_router.rb
@@ -25,8 +25,8 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
       from = update["callback_query"]["from"]
     end
 
-    if defined?(from) && from && User.find_by(telegram_id: from["id"])
-      user = User.find_by(telegram_id: from["id"])
+    if defined?(from) && from
+      user = User.find_or_create_by(telegram_id: from["id"])
       user.telegram_username = from["username"].downcase
       if from["last_name"]
         user.telegram_name = [from["first_name"], from["last_name"]].join(" ")
@@ -38,12 +38,12 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
         User.where(telegram_username: user.telegram_username).each do |u|
           unless user == u
             u.telegram_username = "[#{u.telegram_id}]"
-            u.save
+            u.save!
           end
         end
       end
       
-      user.save
+      user.save!
     end
 
     catch :filtered do
@@ -77,7 +77,7 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
         inline_keyboard: [
           [{
             text: "Log In",
-            login_url: {url: login_callback_url}
+            url: "https://t.me/#{bot.username}?start=login"
           }]
         ]
       }
@@ -97,7 +97,7 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
           reply_markup: {inline_keyboard: [
             [{
               text: "Log In",
-              login_url: {url: login_callback_url}
+              url: "https://t.me/#{bot.username}?start=login"
             }]
           ]}
         end

--- a/spec/requests/telegram_login_spec.rb
+++ b/spec/requests/telegram_login_spec.rb
@@ -1,76 +1,161 @@
 RSpec.describe "/login", telegram_bot: :rails do
   it "should not care about arguments" do
     expect {dispatch_message("/login a b c")}
-    .to respond_with_message(/To complete your registration/) 
+    .to respond_with_message(/To use this bot, you need to log in with/) 
   end
 
-  context "as a new account" do
-    it 'should say to complete your registration' do
-      expect {dispatch_message("/login")}
-      .to respond_with_message(/To complete your registration, /)
-    end
-
-    it "should have an inline keyboard" do
-      dispatch_message("/login")
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
-      .to be_present
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
-      .to include("Log In")
-    end
-  end
-
-  context "as an account without steam registration" do
+  context "for an unregistered user in a group" do
     let(:user) { create(:user) }
 
-    it 'should say to complete your registration' do
-      expect {dispatch_message("/login", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          })}
-      .to respond_with_message(/To complete your registration, /)
+    before(:example) do
+      dispatch_message(
+        "/login",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
+      )
     end
 
-    it "should have an inline keyboard" do
-      dispatch_message("/login", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          })
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
-      .to be_present
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
-      .to include("Log In")
+    it "should respond with the right message" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("To use this bot, you need to log in with")
+      .and include("To complete your registration, open a PM with")
+      .and include("or go to the website and log in with Steam there.")
+      .and not_include("a) Use the button")
+      .and not_include("If you want to unlink your account")
+    end
+
+    it "should have two buttons" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(2)
+    end
+
+    it "should have its first button link to the site" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
+    end
+
+    it "should have its second button link to the chat" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].last.to_s)
+      .to  include("\"Log In (message)\"")
+      .and include(":url")
+      .and include("\"https://t.me/")
+      .and include("?start=login\"")
     end
   end
-  
-  context "as a fully registered account" do
+
+  context "for an unregistered user in a private message" do
+    let(:user) { create(:user) }
+
+    before(:example) do
+      dispatch_message(
+        "/login",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+    end
+
+    it "should respond with the right message" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("To use this bot, you need to log in")
+      .and include("To complete your registration, you have two options")
+      .and include("a) Use the button below")
+      .and not_include("To complete your registration, open a PM with me")
+      .and not_include("Your registration is complete")
+    end
+
+    it "should have one button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+    end
+
+    it "should have its button link to the site" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
+    end
+
+    it "should be possible to follow up with a reply" do
+      count = bot.requests[:sendMessage].count
+
+      allow(SteamID).to receive(:from_string) {
+        SteamID::SteamID.new(63244260)
+      }
+
+      allow_any_instance_of(SteamCondenser::Community::SteamId).to receive(:nickname) {
+        "Tradeless"
+      }
+      allow_any_instance_of(SteamCondenser::Community::SteamId).to receive(:full_avatar_url) {
+        "https://avatars.akamai.steamstatic.com/8d5933942b1be8d27bae80cb472f5d027651a1ad_full.jpg"
+      }
+
+      dispatch_message(
+        "tradeless",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+
+      expect(bot.requests[:sendMessage].count).to eq(count + 1)
+
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("https://steamcommunity.com/profiles/76561198023509988")
+      .and include("If you want to register this account, press the button")
+    end
+  end
+
+  context "for a registered user" do
     let(:user) { create(:user, :steam_registered) }
 
-    it 'should say you are registered' do
-      expect {dispatch_message("/login", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          })}
-      .to respond_with_message(/Your registration is complete/)
+    before(:example) do
+      dispatch_message(
+        "/login",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
     end
 
-    it 'should not affect message for other users' do
-      expect {dispatch_message("/login")}
-      .to respond_with_message(/To complete your registration, /)
+    it "should respond with the right message" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Your registration is complete and you can now")
+      .and not_include("To use this bot, you need to log in")
     end
 
-    it "should have an inline keyboard" do
-      dispatch_message("/login", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          })
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
-      .to be_present
-      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
-      .to include("Log In")
+    it "should have one button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+    end
+
+    it "should have its button link to the site" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
     end
   end
 end

--- a/spec/requests/telegram_matches_spec.rb
+++ b/spec/requests/telegram_matches_spec.rb
@@ -1,36 +1,96 @@
 RSpec.describe "/matches", telegram_bot: :rails do
   context "from an unregistered user" do
-    it "should say that user can't be found" do
-      expect { dispatch_message("/matches", from: {id: 99999}) }
-      .to respond_with_message(/Can't find that user/)
+    before(:example) do
+      dispatch_message("/matches")
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
   context "from an incomplete user" do
-    it "should tell the user they are not registered" do
-      user = create(:user)
+    let(:user) { create(:user) }
 
-      expect { dispatch_message("/matches", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          }) }
-      .to respond_with_message(/That user has not completed their registration/)
+    before(:example) do
+      dispatch_message("/matches", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
-  context "mentioning an unregistered user" do
-    it "should say that user can't be found" do
-      expect { dispatch_message("/matches lkjlkjlkjkljlkjl") }
-      .to respond_with_message(/Can't find that user/)
+  context "mentioning an unregistered user as an unregistered user" do
+    before(:example) do
+      dispatch_message("/matches sdlkjfjkdfjkjkdf")
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
-  context "mentioning an incomplete user" do
-    it "should say that user hasn't completed their registration" do
-      user = create(:user)
-      expect { dispatch_message("/matches #{user.telegram_username}") }
-      .to respond_with_message(/That user has not completed their registration/)
+  context "mentioning an incomplete user as an unregistered user" do
+    let(:user) { create(:user) }
+    before(:example) do
+      dispatch_message("/matches #{user.telegram_username}")
+    end
+    
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 

--- a/spec/requests/telegram_profile_spec.rb
+++ b/spec/requests/telegram_profile_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "/profile", telegram_bot: :rails do
+  let(:user) { create(:user, :steam_registered) }
   context "as a registered user" do
     it "should respond with their steam url" do
-      user = create(:user, :steam_registered)
       dispatch_message("/profile", from: {
             id: user.telegram_id,
             username: user.telegram_username,
@@ -12,33 +12,92 @@ RSpec.describe "/profile", telegram_bot: :rails do
   end
 
   context "as an unregistered user" do
+    before(:example) do
+      dispatch_message("/profile")
+    end
+
     it "should say you need to register" do
-      expect {dispatch_message("/profile")}
-      .to respond_with_message(/You need to register before/)
+      expect(bot.requests[:sendMessage].last[:text])
+      .to include("You need to register before")
+    end
+
+    it "should provide a button to pm the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")
     end
   end
 
   context "as an incomplete user" do
-    it "should say you need to complete your registration" do
-      user = create(:user)
-      expect {dispatch_message("/profile", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          })}
-      .to respond_with_message(/You need to complete your registration/)
+    let(:user) { create(:user) }
+    
+    before(:example) do
+      dispatch_message("/profile", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
+    end
+
+    it "should say that you need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to include("You need to register before")
+    end
+
+    it "should provide a button to pm the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")
+    end
+  end
+
+  context "mentioning an unknown user" do
+    it "should say it doesn't know that user" do
+      expect(bot).to receive(:request).and_wrap_original do |m, *args|
+        m.call(*args)
+        {"ok"=>true, "result"=>{"message_id"=>120}}
+      end
+
+      expect { dispatch_message("/profile asdfsf", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      }) }
+      .to  respond_with_message(/I don't know that user, sorry!/)
+      .and respond_with_message(/They may not be registered yet./)
+    end
+  end
+  
+  context "mentioning an incomplete user" do
+    it "should say that user needs to complete their registration" do
+      user2 = create(:user)
+      expect { dispatch_message(
+        "/profile #{user2.telegram_username}", from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
+      ) }
+      .to  respond_with_message(/That user has not signed in/)
+      .and respond_with_message(/Once they sign in, their data will become available/)
     end
   end
 
   context "mentioning a registered user" do
     it "should respond with that user's steam link" do
-      user = create(:user, :steam_registered)
       dispatch_message("/profile #{user.telegram_username}")
       expect(bot.requests[:sendMessage].last[:text]).to include(user.steam_url)
     end
 
     it "should not respond with the caller's steam link" do
-      user  = create(:user, :steam_registered)
       user2 = create(:user, :steam_registered)
       dispatch_message("/profile #{user2.telegram_username}", from: {
             id: user.telegram_id,
@@ -49,31 +108,15 @@ RSpec.describe "/profile", telegram_bot: :rails do
     end
   end
 
-  context "mentioning an unregistered user" do
-    it "should say it can't find that user" do
-      expect { dispatch_message("/profile asdfasdfsdf") }
-      .to respond_with_message(/Can't find that user/)
-    end
-  end
-
-  context "mentioning an incomplete user" do
-    it "should tell the user to complete their registration" do
-      user = create(:user)
-      expect {dispatch_message("/profile #{user.telegram_username}")}
-      .to respond_with_message(/That user has not completed their registration/)
-    end
-  end
-
   context "with invalid arguments" do
-    it "should say it can't find that user" do
-      user = create(:user, :steam_registered)
+    it "should say it doesn't know that user" do
       dispatch_message("/profile asdsfgflkdg wehjkr", from: {
             id: user.telegram_id,
             username: user.telegram_username,
             first_name: user.telegram_name
           })
       expect(bot.requests[:sendMessage].last[:text])
-      .to include("Can't find that user")
+      .to include("I don't know that user, sorry!")
     end
   end
 end

--- a/spec/requests/telegram_start_spec.rb
+++ b/spec/requests/telegram_start_spec.rb
@@ -1,11 +1,288 @@
 RSpec.describe "/start", telegram_bot: :rails do
-  it "should respond with help text" do
-    expect {dispatch_message("/start")}
-    .to respond_with_message(/Hello! I can fetch your Dota 2 match data/)
+  context "in a group chat" do
+    before(:example) do
+      dispatch_message("/start")
+    end
+
+    it "should include the default text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Hello! I can fetch your Dota 2 match data")
+    end
+
+    it "should include the group chat text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("To let me show your stats, I will need to know which")
+      .and include("If you want to use my commands, you need to")
+      .and include("complete your registration on the site")
+      .and include("or use the other button and complete it in chat")
+    end
+
+    it "should include two buttons" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(2)
+    end
+
+    it "should link to the site with the first button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
+    end
+
+    it "should link to a chat with the second button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].last.to_s)
+      .to  include("\"Log In (message)\"")
+      .and include(":url")
+      .and include("\"https://t.me")
+      .and include("?start=login\"")
+    end
   end
 
-  it "should not care about arguments" do
-    expect {dispatch_message("/start as df sfdlkwe")}
-    .to respond_with_message(/Hello! I can fetch your Dota 2 match data/)
+  context "in a registered user's direct messages" do
+    let(:user) { create(:user, :steam_registered) }
+
+    before(:example) do
+      dispatch_message(
+        "/start",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+    end
+
+    it "should include the default text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Hello! I can fetch your Dota 2 match data")
+    end
+
+    it "should include the registered user text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You are already signed in and ready")
+      .and include("If you want to edit or remove your registration")
+      .and include("You can also send me a link to a Steam profile")
+    end
+
+    it "should include a single button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+    end
+
+    it "should link to the site with its button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
+    end
+  end
+
+  context "in an unregistered user's direct messages" do
+    let(:user) { create(:user) }
+
+    before(:example) do
+      dispatch_message(
+        "/start",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+    end
+
+    it "should include the default text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Hello! I can fetch your Dota 2 match data")
+    end
+
+    it "should include the unregistered user text" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("To let me show your stats, you have two options")
+      .and include("a) Use the button below this message and log in")
+      .and include("b) Send a message with a link to your Steam profile!")
+    end
+
+    it "should include a single button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+    end
+
+    it "should link to the site with its button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In (website)\"")
+      .and include(":login_url")
+      .and include("/auth/telegram/callback")
+    end
+  end
+
+  context "in-chat registration" do
+    let(:user) { create(:user) }
+
+    before(:example) do
+      dispatch_message(
+        "/start",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+
+      allow(SteamID).to receive(:from_string) {
+        SteamID::SteamID.new(63244260)
+      }
+
+      allow_any_instance_of(SteamCondenser::Community::SteamId).to receive(:nickname) {
+        "Tradeless"
+      }
+      allow_any_instance_of(SteamCondenser::Community::SteamId).to receive(:full_avatar_url) {
+        "https://avatars.akamai.steamstatic.com/8d5933942b1be8d27bae80cb472f5d027651a1ad_full.jpg"
+      }
+
+      dispatch_message(
+        "63244260",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+    end
+
+    it "should respond with the right message" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("https://steamcommunity.com/profiles/76561198023509988")
+      .and include("If you want to register this account, press the button")
+    end
+
+    it "should have one button" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+    end
+
+    it "should have its button lead to registering that account" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Register this account\"")
+      .and include("\"register:63244260\"")
+    end
+
+    it "should allow to try again" do
+      count = bot.requests[:sendMessage].count
+
+      dispatch_message(
+        "63244260",
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        },
+        chat: {
+          id: user.telegram_id,
+          type: "private"
+        }
+      )
+
+      expect(bot.requests[:sendMessage].count).to eq(count + 1)
+
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("https://steamcommunity.com/profiles/76561198023509988")
+      .and include("If you want to register this account, press the button")
+    end
+
+    it "should change the user's registration when they press the button" do
+      dispatch(callback_query: {
+        data: "register:63244260",
+        message: {
+          message_id: 900,
+          chat: {id: user.telegram_id},
+        },
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
+      })
+
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Your registration is now complete and you can")
+      .and include("If you want to edit or remove your registration")
+      .and not_include("Another account in the database had")
+
+      db_user = User.find_by(telegram_id: user.telegram_id)
+      expect(db_user.steam_id)
+      .to eq(63244260)
+      expect(db_user.steam_url)
+      .to eq("https://steamcommunity.com/profiles/76561198023509988")
+    end
+
+    it "should override conflicting registrations" do
+      user2 = create(
+        :user,
+        :steam_registered,
+        steam_id64: 76561198023509988,
+        steam_id: 63244260,
+        steam_url: "https://steamcommunity.com/profiles/76561198023509988"
+      )
+
+      dispatch(callback_query: {
+        data: "register:63244260",
+        message: {
+          message_id: 900,
+          chat: {id: user.telegram_id},
+        },
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
+      })
+
+      db_user = User.find_by(telegram_id: user2.telegram_id)
+      expect(db_user.steam_id).to eq(nil)
+    end
+
+    it "should notify if a registration was removed" do
+      user2 = create(
+        :user,
+        :steam_registered,
+        steam_id64: 76561198023509988,
+        steam_id: 63244260,
+        steam_url: "https://steamcommunity.com/profiles/76561198023509988"
+      )
+
+      dispatch(callback_query: {
+        data: "register:63244260",
+        message: {
+          message_id: 900,
+          chat: {id: user.telegram_id},
+        },
+        from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
+      })
+
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("Another account in the database had this")
+      .and include("their registration has been removed.")
+    end
   end
 end

--- a/spec/requests/telegram_winrate_spec.rb
+++ b/spec/requests/telegram_winrate_spec.rb
@@ -1,37 +1,96 @@
 RSpec.describe "/winrate", telegram_bot: :rails do
   context "from an unregistered user" do
-    it "should say that user can't be found" do
-      expect { dispatch_message("/winrate", from: {id: 99999}) }
-      .to respond_with_message(/Can't find that user/)
+    before(:example) do
+      dispatch_message("/winrate")
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
   context "from an incomplete user" do
-    it "should tell the user that they are not registered" do
-      user = create(:user)
+    let(:user) { create(:user) }
 
-      expect { dispatch_message("/winrate", from: {
-            id: user.telegram_id,
-            username: user.telegram_username,
-            first_name: user.telegram_name
-          }) }
-      .to respond_with_message(/That user has not completed their registration/)
+    before(:example) do
+      dispatch_message("/winrate", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
-  context "mentioning an unregistered user" do
-    it "should say that user can't be found" do
-      expect { dispatch_message("/winrate sdlkjfjkdfjkjkdf") }
-      .to respond_with_message(/Can't find that user/)
+  context "mentioning an unregistered user as an unregistered user" do
+    before(:example) do
+      dispatch_message("/winrate sdlkjfjkdfjkjkdf")
+    end
+
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
+
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 
-  context "mentioning an incomplete user" do
-    it "should tell the user that they are not registered" do
-      user = create(:user)
+  context "mentioning an incomplete user as an unregistered user" do
+    let(:user) { create(:user) }
+    before(:example) do
+      dispatch_message("/winrate #{user.telegram_username}")
+    end
+    
+    it "should tell that user they need to register" do
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include("You need to register before you can use that command")
+      .and include("Use the button below to open a chat with me")
+    end
 
-      expect { dispatch_message("/winrate #{user.telegram_username}") }
-      .to respond_with_message(/That user has not completed their registration/)
+    it "should have a button to open a chat with the bot" do
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+      .to eq(1)
+
+      expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("\"Log In\"")
+      .and include("https://t.me/")
+      .and include(":url")  
     end
   end
 


### PR DESCRIPTION
This creates an alternative way for users to sign in by talking to the bot off of `/start` and `/login`. Also improves the rendering of error messages. Closes #53.

Important change is that users are now automatically registered upon interacting with the bot, so default error messages for not being registered have also been updated. Closes #65.