### PR TITLE
Fix anonymous players being matched against the database

### DIFF
--- a/app/models/match_player.rb
+++ b/app/models/match_player.rb
@@ -52,6 +52,7 @@ class MatchPlayer
   end
 
   def known?
+    self.account_id && self.account_id != 0 && 
     !User.find_by(steam_id: self.account_id).nil?
   end
 

--- a/spec/requests/telegram_match_spec.rb
+++ b/spec/requests/telegram_match_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe "/match", telegram_bot: :rails do
       .and not_include(user.telegram_username)
     end
 
+    it "should not fill in unregistered users" do
+      user2 = create(:user)
+      dispatch_message("/match 123456")
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  not_include(user2.telegram_username)
+      .and not_include(user2.telegram_name)
+    end
+
     it "should give a button to OpenDota" do
       allow(Match).to receive(:from_api) do
         build(:match, match_id: 12345)


### PR DESCRIPTION
In the output of `/match`, the bot would look anonymous users up in the database, matching the first user who did not have a Steam account registered. It doesn't do that anymore.